### PR TITLE
Allow setting one channel to be the opacity

### DIFF
--- a/multivariate_view/app/app.py
+++ b/multivariate_view/app/app.py
@@ -123,7 +123,7 @@ class App:
         if self.opacity_channel is not None:
             # Extract the opacity data
             opacity_idx = header.index(self.opacity_channel)
-            self.opacity_data = data[:, :, :, opacity_idx]
+            self.opacity_data = _normalize_data(data[:, :, :, opacity_idx])
 
             header.pop(opacity_idx)
             data = np.delete(data, opacity_idx, axis=3)

--- a/multivariate_view/app/app.py
+++ b/multivariate_view/app/app.py
@@ -191,6 +191,11 @@ class App:
         # Only store nonzero data. We will reconstruct the zeros later.
         self.nonzero_data = flattened_data[self.nonzero_indices]
 
+        # Update this for histogram/percent infos
+        self.raw_unpadded_flattened_data = data.reshape(
+            np.prod(self.data_shape), self.num_channels
+        )
+
         # Trigger an update of the data
         self.update_gbc()
 


### PR DESCRIPTION
This allows setting one channel to be the opacity. This also removes that channel from the channels that are used in the color wheel.

Fixes: #13